### PR TITLE
Add Renovate for dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,36 @@
+{
+  extends: [
+    'config:base',
+
+    // Make sure we get a single PR combining all updates
+    'group:all',
+  ],
+
+  // Disable dependency dashboard
+  dependencyDashboard: false,
+
+  // We will keep simple-icons up-to-date separately from renovate
+  ignoreDeps: ['simple-icons'],
+
+  lockFileMaintenance: {
+    extends: [
+      // Make sure we get a single PR combining all updates
+      'group:all',
+    ],
+
+    // Explicitly enable lockfile maintenance
+    enabled: true,
+
+    // This schedule should be the same as the general schedule!
+    schedule: 'on the 2nd and 4th day instance on sunday after 11pm',
+  },
+
+  // Use our labelling system
+  labels: ['dependencies'],
+
+  // Schedule the PRs to interleave with our release schedule
+  schedule: 'on the 2nd and 4th day instance on sunday after 11pm',
+
+  // We generally always want the major version
+  separateMajorMinor: false,
+}


### PR DESCRIPTION
Just let me know if is not required for some reason. If everything is OK, we need to make the next changes before merge:

- [x] Give Renovate permissions for this repository in  simple-icons's organization `Installed Github Apps` -> `Renovate` -> `Repository Access`.
- [x] Disable Dependabot security updates to prevent security updates duplicity as has been done in https://github.com/simple-icons/simple-icons-font/pull/134#issuecomment-909453576